### PR TITLE
Adds Gravity Helper support to springs

### DIFF
--- a/Entities/NoDashRefillSpring.cs
+++ b/Entities/NoDashRefillSpring.cs
@@ -202,40 +202,42 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
             if (Orientation == Orientations.Floor) {
                 if (realY >= 0f) {
-                    bounceAnimate.Invoke(this, noParams);
-                    if (inverted) {
+                    if (inverted && inactiveTimer <= 0f) {
                         InvertedSuperBounce(player, Top - player.Height);
-                    } else {
+                        inactiveTimer = 0.1f;
+                        bounced = true;
+                    } else if (!inverted) {
                         player.SuperBounce(Top);
+                        bounced = true;
                     }
-                    bounced = true;
                 }
             } else if (Orientation == Orientations.WallLeft) {
                 if (player.SideBounce(1, Right, CenterY)) {
-                    bounceAnimate.Invoke(this, noParams);
                     bounced = true;
                 }
             } else if (Orientation == Orientations.WallRight) {
                 if (player.SideBounce(-1, Left, CenterY)) {
-                    bounceAnimate.Invoke(this, noParams);
                     bounced = true;
                 }
             } else if (Orientation == Orientations.Ceiling) {
-                if (realY <= 0f && inactiveTimer <= 0f) {
-                    bounceAnimate.Invoke(this, noParams);
-                    if (inverted) {
-                        player.SuperBounce(Bottom);
-                    } else {
+                if (realY <= 0f) {
+                    if (!inverted && inactiveTimer <= 0f) {
                         InvertedSuperBounce(player, Bottom + player.Height);
+                        inactiveTimer = 0.1f;
+                        bounced = true;
+                    } else if (inverted) {
+                        player.SuperBounce(Bottom);
+                        bounced = true;
                     }
-                    inactiveTimer = 0.1f;
-                    bounced = true;
                 }
             } else {
                 throw new Exception("Orientation not supported!");
             }
 
             if (bounced) {
+                // animate spring
+                bounceAnimate.Invoke(this, noParams);
+
                 // Restore original dash count.
                 player.Dashes = originalDashCount;
 

--- a/Entities/UpsideDownJumpThru.cs
+++ b/Entities/UpsideDownJumpThru.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Celeste.Mod.MaxHelpingHand.Module;
 
 namespace Celeste.Mod.MaxHelpingHand.Entities {
     [CustomEntity("MaxHelpingHand/UpsideDownJumpThru")]
@@ -27,18 +28,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
         private static readonly Hitbox normalHitbox = new Hitbox(8f, 11f, -4f, -11f);
 
-        [ModImportName("GravityHelper")]
-        private class GravityHelper {
-#pragma warning disable CS0649 // it is actually initialized by ModInterop
-            public static Func<bool> IsPlayerInverted;
-#pragma warning restore CS0649
-        }
-
         public static void Load() {
             On.Celeste.LevelLoader.ctor += onLevelLoad;
             On.Celeste.OverworldLoader.ctor += onOverworldLoad;
-
-            typeof(GravityHelper).ModInterop();
         }
 
         public static void Unload() {
@@ -483,7 +475,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
         }
 
         public override void MoveVExact(int move) {
-            bool playerInverted = GravityHelper.IsPlayerInverted?.Invoke() ?? false;
+            bool playerInverted = GravityHelperImports.IsPlayerInverted();
 
             if (!playerInverted) {
                 // if we are going to hit the player while moving down... this means we are pushing them down. So... we need to push them down :theoreticalwoke:

--- a/Module/GravityHelperImports.cs
+++ b/Module/GravityHelperImports.cs
@@ -1,0 +1,13 @@
+using System;
+using MonoMod.ModInterop;
+
+namespace Celeste.Mod.MaxHelpingHand.Module {
+    public static class GravityHelperImports {
+        [ModImportName("GravityHelper")]
+        public static class Interop {
+            public static Func<bool> IsPlayerInverted;
+        }
+
+        public static bool IsPlayerInverted() => Interop.IsPlayerInverted?.Invoke() ?? false;
+    }
+}

--- a/Module/MaxHelpingHandModule.cs
+++ b/Module/MaxHelpingHandModule.cs
@@ -110,6 +110,7 @@ namespace Celeste.Mod.MaxHelpingHand.Module {
                 typeof(MaxHelpingHandModule).GetMethod("onModRegister", BindingFlags.NonPublic | BindingFlags.Instance), this);
 
             typeof(LuaCutscenesUtils).ModInterop();
+            typeof(GravityHelperImports.Interop).ModInterop();
         }
 
         public override void Unload() {


### PR DESCRIPTION
* Refactors inverted super bounce out into its own method so that it can be reused for floor springs.
* While Madeline is inverted, `inactiveTime` is used for floor springs rather than ceiling springs.
* `bounceAnimate` now happens after the player is bounced, since the order doesn't matter and it reduces code repetition.
* Gravity Helper imports are now their own class since it needs to be used outside of `UpsideDownJumpThru`.