### PR TITLE
Make spinner neighbor asynchronous unless required to remove lag spik…

### DIFF
--- a/Entities/SpinnerBreakingBallGeneric.cs
+++ b/Entities/SpinnerBreakingBallGeneric.cs
@@ -86,15 +86,15 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
             base.Update();
 
-            List<SpinnerType> listOfSpinners;
+            IEnumerable<SpinnerType> listOfSpinners;
             if (spinnerNeighbors == null) {
                 if (computeSpinnerNeighbors == null) {
                     computeSpinnerNeighborsToken = new CancellationTokenSource();
                     computeSpinnerNeighbors = computeSpinnerConnections(computeSpinnerNeighborsToken.Token);
                 }
-                listOfSpinners = Scene.Tracker.GetEntities<SpinnerType>().OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color)).ToList();
+                listOfSpinners = Scene.Tracker.GetEntities<SpinnerType>().OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color));
             } else {
-                listOfSpinners = spinnerNeighbors.Keys.ToList();
+                listOfSpinners = spinnerNeighbors.Keys;
             }
 
             // we want to check all spinners explicitly instead of just going CollideCheck<SpinnerType>(),

--- a/Entities/SpinnerBreakingBallGeneric.cs
+++ b/Entities/SpinnerBreakingBallGeneric.cs
@@ -7,20 +7,16 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Celeste.Mod.MaxHelpingHand.Entities
-{
+namespace Celeste.Mod.MaxHelpingHand.Entities {
     /**
      * Common behavior across all spinner breaking balls: grouping spinners, and well... breaking them.
      */
-    public abstract class SpinnerBreakingBallGeneric<SpinnerType, ColorType> : TheoCrystal where SpinnerType : Entity
-    {
-        public static void Load()
-        {
+    public abstract class SpinnerBreakingBallGeneric<SpinnerType, ColorType> : TheoCrystal where SpinnerType : Entity {
+        public static void Load() {
             On.Celeste.TheoCrystal.Die += onTheoCrystalDie;
         }
 
-        public static void Unload()
-        {
+        public static void Unload() {
             On.Celeste.TheoCrystal.Die -= onTheoCrystalDie;
         }
 
@@ -38,8 +34,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
         private Dictionary<SpinnerType, HashSet<SpinnerType>> spinnerNeighbors;
         private HashSet<SpinnerType> shatteredSpinners = new HashSet<SpinnerType>();
 
-        public SpinnerBreakingBallGeneric(EntityData data, Vector2 offset, EntityID entityID, ColorType color) : base(data.Position + offset)
-        {
+        public SpinnerBreakingBallGeneric(EntityData data, Vector2 offset, EntityID entityID, ColorType color) : base(data.Position + offset) {
             // fix Theo's "crash when leaving behind and going up" bug
             Tag = 0;
 
@@ -58,25 +53,21 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
             Add(sprite);
             new DynData<TheoCrystal>(this)["sprite"] = sprite;
 
-            Add(new TransitionListener()
-            {
+            Add(new TransitionListener() {
                 OnOutBegin = onTransitionOut
             });
         }
 
-        private void onTransitionOut()
-        {
+        private void onTransitionOut() {
             // wipe the spinner connections so that they are computed again after the transition (in the new room).
             spinnerNeighbors = null;
         }
 
-        public override void Awake(Scene scene)
-        {
+        public override void Awake(Scene scene) {
             base.Awake(scene);
 
             Player player = scene.Tracker.GetEntity<Player>();
-            if (player?.Holding?.Entity is SpinnerBreakingBallGeneric<SpinnerType, ColorType> ball && ball.entityID.Level == entityID.Level && ball.entityID.ID == entityID.ID)
-            {
+            if (player?.Holding?.Entity is SpinnerBreakingBallGeneric<SpinnerType, ColorType> ball && ball.entityID.Level == entityID.Level && ball.entityID.ID == entityID.ID) {
                 // oops, the player is carrying a copy of ourselves from another room! commit remove self.
                 RemoveSelf();
             }
@@ -85,40 +76,31 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
             IDCache = new();
         }
 
-        public override void Update()
-        {
-            if (Hold.IsHeld)
-            {
+        public override void Update() {
+            if (Hold.IsHeld) {
                 floating = false;
             }
-            if (floating)
-            {
+            if (floating) {
                 new DynData<Holdable>(Hold)["gravityTimer"] = 1f;
             }
 
             base.Update();
 
             List<SpinnerType> listOfSpinners;
-            if (spinnerNeighbors == null)
-            {
-                if (computeSpinnerNeighbors == null)
-                {
+            if (spinnerNeighbors == null) {
+                if (computeSpinnerNeighbors == null) {
                     computeSpinnerNeighborsToken = new CancellationTokenSource();
                     computeSpinnerNeighbors = computeSpinnerConnections(computeSpinnerNeighborsToken.Token);
                 }
                 listOfSpinners = Scene.Tracker.GetEntities<SpinnerType>().OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color)).ToList();
-            }
-            else
-            {
+            } else {
                 listOfSpinners = spinnerNeighbors.Keys.ToList();
             }
 
             // we want to check all spinners explicitly instead of just going CollideCheck<SpinnerType>(),
             // to include those turned off because the player is too far.
-            foreach (SpinnerType candidate in listOfSpinners)
-            {
-                if (candidate.Scene != null && candidate.CollideCheck(this))
-                {
+            foreach (SpinnerType candidate in listOfSpinners) {
+                if (candidate.Scene != null && candidate.CollideCheck(this)) {
                     if (!computeSpinnerNeighbors.IsCompleted) computeSpinnerNeighbors.Wait();
                     if (computeSpinnerNeighbors.IsFaulted) Logger.Log("MaxHelpingHand/SpinnerBreakingBall", $"Failed to compute Spinner Neighbors: {computeSpinnerNeighbors.Exception}");
                     if (spinnerNeighbors == null) return;
@@ -129,30 +111,24 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
             }
         }
 
-        public override void Removed(Scene scene)
-        {
+        public override void Removed(Scene scene) {
             base.Removed(scene);
             computeSpinnerNeighborsToken.Cancel();
         }
-        private Task computeSpinnerConnections(CancellationToken cancelToken)
-        {
-            return Task.Run(() =>
-            {
+        private Task computeSpinnerConnections(CancellationToken cancelToken) {
+            return Task.Run(() => {
                 Dictionary<SpinnerType, HashSet<SpinnerType>> neighbors = new();
 
                 // take all spinners on screen, filter those with a matching color
                 List<SpinnerType> allSpinnersInScreen = Scene.Tracker.GetEntities<SpinnerType>()
                     .OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color)).ToList();
 
-                foreach (SpinnerType spinner1 in allSpinnersInScreen)
-                {
-                    if (!neighbors.ContainsKey(spinner1))
-                    {
+                foreach (SpinnerType spinner1 in allSpinnersInScreen) {
+                    if (!neighbors.ContainsKey(spinner1)) {
                         neighbors[spinner1] = new HashSet<SpinnerType>();
                     }
 
-                    foreach (SpinnerType spinner2 in allSpinnersInScreen)
-                    {
+                    foreach (SpinnerType spinner2 in allSpinnersInScreen) {
                         int spinner1ID;
                         int spinner2ID;
 
@@ -160,14 +136,11 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
                         // Since we are working async this is possible.
                         // This cache is to make sure every object is only used once
                         // unsure if the lock is actually needed
-                        lock (IDCache)
-                        {
-                            if (!IDCache.ContainsKey(spinner1))
-                            {
+                        lock (IDCache) {
+                            if (!IDCache.ContainsKey(spinner1)) {
                                 IDCache[spinner1] = new DynData<SpinnerType>(spinner1).Get<int>("ID");
                             }
-                            if (!IDCache.ContainsKey(spinner2))
-                            {
+                            if (!IDCache.ContainsKey(spinner2)) {
                                 IDCache[spinner2] = new DynData<SpinnerType>(spinner2).Get<int>("ID");
                             }
 
@@ -177,12 +150,10 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
 
                         // to connect spinners, we are using the same criteria as "spinner juice" generation in the game.
                         if (spinner2ID > spinner1ID
-                            && getAttachToSolid(spinner2) == getAttachToSolid(spinner1) && (spinner2.Position - spinner1.Position).LengthSquared() < 576f)
-                        {
+                            && getAttachToSolid(spinner2) == getAttachToSolid(spinner1) && (spinner2.Position - spinner1.Position).LengthSquared() < 576f) {
 
                             // register 2 as a neighbor of 1, and 1 as a neighbor of 2.
-                            if (!neighbors.ContainsKey(spinner2))
-                            {
+                            if (!neighbors.ContainsKey(spinner2)) {
                                 neighbors[spinner2] = new HashSet<SpinnerType>();
                             }
 
@@ -196,34 +167,26 @@ namespace Celeste.Mod.MaxHelpingHand.Entities
             }, cancelToken);
         }
 
-        private void shatterSpinner(SpinnerType spinner)
-        {
+        private void shatterSpinner(SpinnerType spinner) {
             // don't break already broken spinners!
             if (spinner.Scene == null) return;
 
             destroySpinner(spinner);
             shatteredSpinners.Add(spinner);
 
-            if (spinnerNeighbors.ContainsKey(spinner))
-            {
-                foreach (SpinnerType neighbor in spinnerNeighbors[spinner])
-                {
-                    if (!shatteredSpinners.Contains(neighbor))
-                    {
+            if (spinnerNeighbors.ContainsKey(spinner)) {
+                foreach (SpinnerType neighbor in spinnerNeighbors[spinner]) {
+                    if (!shatteredSpinners.Contains(neighbor)) {
                         shatterSpinner(neighbor);
                     }
                 }
             }
         }
 
-        private static void onTheoCrystalDie(On.Celeste.TheoCrystal.orig_Die orig, TheoCrystal self)
-        {
-            if (self is SpinnerBreakingBallGeneric<SpinnerType, ColorType>)
-            {
+        private static void onTheoCrystalDie(On.Celeste.TheoCrystal.orig_Die orig, TheoCrystal self) {
+            if (self is SpinnerBreakingBallGeneric<SpinnerType, ColorType>) {
                 self.RemoveSelf();
-            }
-            else
-            {
+            } else {
                 orig(self);
             }
         }

--- a/Entities/SpinnerBreakingBallGeneric.cs
+++ b/Entities/SpinnerBreakingBallGeneric.cs
@@ -4,17 +4,23 @@ using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace Celeste.Mod.MaxHelpingHand.Entities {
+namespace Celeste.Mod.MaxHelpingHand.Entities
+{
     /**
      * Common behavior across all spinner breaking balls: grouping spinners, and well... breaking them.
      */
-    public abstract class SpinnerBreakingBallGeneric<SpinnerType, ColorType> : TheoCrystal where SpinnerType : Entity {
-        public static void Load() {
+    public abstract class SpinnerBreakingBallGeneric<SpinnerType, ColorType> : TheoCrystal where SpinnerType : Entity
+    {
+        public static void Load()
+        {
             On.Celeste.TheoCrystal.Die += onTheoCrystalDie;
         }
 
-        public static void Unload() {
+        public static void Unload()
+        {
             On.Celeste.TheoCrystal.Die -= onTheoCrystalDie;
         }
 
@@ -25,10 +31,15 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
         private bool floating;
 
+        private Task computeSpinnerNeighbors;
+        private CancellationTokenSource computeSpinnerNeighborsToken;
+        private static Dictionary<Entity, int> IDCache;
+
         private Dictionary<SpinnerType, HashSet<SpinnerType>> spinnerNeighbors;
         private HashSet<SpinnerType> shatteredSpinners = new HashSet<SpinnerType>();
 
-        public SpinnerBreakingBallGeneric(EntityData data, Vector2 offset, EntityID entityID, ColorType color) : base(data.Position + offset) {
+        public SpinnerBreakingBallGeneric(EntityData data, Vector2 offset, EntityID entityID, ColorType color) : base(data.Position + offset)
+        {
             // fix Theo's "crash when leaving behind and going up" bug
             Tag = 0;
 
@@ -47,101 +58,172 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             Add(sprite);
             new DynData<TheoCrystal>(this)["sprite"] = sprite;
 
-            Add(new TransitionListener() {
+            Add(new TransitionListener()
+            {
                 OnOutBegin = onTransitionOut
             });
         }
 
-        private void onTransitionOut() {
+        private void onTransitionOut()
+        {
             // wipe the spinner connections so that they are computed again after the transition (in the new room).
             spinnerNeighbors = null;
         }
 
-        public override void Awake(Scene scene) {
+        public override void Awake(Scene scene)
+        {
             base.Awake(scene);
 
             Player player = scene.Tracker.GetEntity<Player>();
-            if (player?.Holding?.Entity is SpinnerBreakingBallGeneric<SpinnerType, ColorType> ball && ball.entityID.Level == entityID.Level && ball.entityID.ID == entityID.ID) {
+            if (player?.Holding?.Entity is SpinnerBreakingBallGeneric<SpinnerType, ColorType> ball && ball.entityID.Level == entityID.Level && ball.entityID.ID == entityID.ID)
+            {
                 // oops, the player is carrying a copy of ourselves from another room! commit remove self.
                 RemoveSelf();
             }
+
+            // reset cache
+            IDCache = new();
         }
 
-        public override void Update() {
-            if (Hold.IsHeld) {
+        public override void Update()
+        {
+            if (Hold.IsHeld)
+            {
                 floating = false;
             }
-            if (floating) {
+            if (floating)
+            {
                 new DynData<Holdable>(Hold)["gravityTimer"] = 1f;
             }
 
             base.Update();
 
-            if (spinnerNeighbors == null) {
-                // connections weren't computed yet, do that right now!
-                computeSpinnerConnections();
-            } else {
-                // we want to check all spinners explicitly instead of just going CollideCheck<SpinnerType>(),
-                // to include those turned off because the player is too far.
-                foreach (SpinnerType candidate in spinnerNeighbors.Keys) {
-                    if (candidate.Scene != null && candidate.CollideCheck(this)) {
-                        // BOOM! recursively shatter spinners.
-                        shatterSpinner(candidate);
-                        RemoveSelf();
-                    }
+            List<SpinnerType> listOfSpinners;
+            if (spinnerNeighbors == null)
+            {
+                if (computeSpinnerNeighbors == null)
+                {
+                    computeSpinnerNeighborsToken = new CancellationTokenSource();
+                    computeSpinnerNeighbors = computeSpinnerConnections(computeSpinnerNeighborsToken.Token);
+                }
+                listOfSpinners = Scene.Tracker.GetEntities<SpinnerType>().OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color)).ToList();
+            }
+            else
+            {
+                listOfSpinners = spinnerNeighbors.Keys.ToList();
+            }
+
+            // we want to check all spinners explicitly instead of just going CollideCheck<SpinnerType>(),
+            // to include those turned off because the player is too far.
+            foreach (SpinnerType candidate in listOfSpinners)
+            {
+                if (candidate.Scene != null && candidate.CollideCheck(this))
+                {
+                    if (!computeSpinnerNeighbors.IsCompleted) computeSpinnerNeighbors.Wait();
+                    if (computeSpinnerNeighbors.IsFaulted) Logger.Log("MaxHelpingHand/SpinnerBreakingBall", $"Failed to compute Spinner Neighbors: {computeSpinnerNeighbors.Exception}");
+                    if (spinnerNeighbors == null) return;
+                    // BOOM! recursively shatter spinners.
+                    shatterSpinner(candidate);
+                    RemoveSelf();
                 }
             }
         }
 
-        private void computeSpinnerConnections() {
-            spinnerNeighbors = new Dictionary<SpinnerType, HashSet<SpinnerType>>();
+        public override void Removed(Scene scene)
+        {
+            base.Removed(scene);
+            computeSpinnerNeighborsToken.Cancel();
+        }
+        private Task computeSpinnerConnections(CancellationToken cancelToken)
+        {
+            return Task.Run(() =>
+            {
+                Dictionary<SpinnerType, HashSet<SpinnerType>> neighbors = new();
 
-            // take all spinners on screen, filter those with a matching color
-            List<SpinnerType> allSpinnersInScreen = Scene.Tracker.GetEntities<SpinnerType>()
-                .OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color)).ToList();
+                // take all spinners on screen, filter those with a matching color
+                List<SpinnerType> allSpinnersInScreen = Scene.Tracker.GetEntities<SpinnerType>()
+                    .OfType<SpinnerType>().Where(spinner => getColor(spinner).Equals(color)).ToList();
 
-            foreach (SpinnerType spinner1 in allSpinnersInScreen) {
-                if (!spinnerNeighbors.ContainsKey(spinner1)) {
-                    spinnerNeighbors[spinner1] = new HashSet<SpinnerType>();
-                }
+                foreach (SpinnerType spinner1 in allSpinnersInScreen)
+                {
+                    if (!neighbors.ContainsKey(spinner1))
+                    {
+                        neighbors[spinner1] = new HashSet<SpinnerType>();
+                    }
 
-                foreach (SpinnerType spinner2 in allSpinnersInScreen) {
-                    // to connect spinners, we are using the same criteria as "spinner juice" generation in the game.
-                    if (new DynData<SpinnerType>(spinner2).Get<int>("ID") > new DynData<SpinnerType>(spinner1).Get<int>("ID")
-                        && getAttachToSolid(spinner2) == getAttachToSolid(spinner1) && (spinner2.Position - spinner1.Position).LengthSquared() < 576f) {
+                    foreach (SpinnerType spinner2 in allSpinnersInScreen)
+                    {
+                        int spinner1ID;
+                        int spinner2ID;
 
-                        // register 2 as a neighbor of 1, and 1 as a neighbor of 2.
-                        if (!spinnerNeighbors.ContainsKey(spinner2)) {
-                            spinnerNeighbors[spinner2] = new HashSet<SpinnerType>();
+                        // If DynData is created on same object multiple times it will crash
+                        // Since we are working async this is possible.
+                        // This cache is to make sure every object is only used once
+                        // unsure if the lock is actually needed
+                        lock (IDCache)
+                        {
+                            if (!IDCache.ContainsKey(spinner1))
+                            {
+                                IDCache[spinner1] = new DynData<SpinnerType>(spinner1).Get<int>("ID");
+                            }
+                            if (!IDCache.ContainsKey(spinner2))
+                            {
+                                IDCache[spinner2] = new DynData<SpinnerType>(spinner2).Get<int>("ID");
+                            }
+
+                            spinner1ID = IDCache[spinner1];
+                            spinner2ID = IDCache[spinner2];
                         }
 
-                        spinnerNeighbors[spinner1].Add(spinner2);
-                        spinnerNeighbors[spinner2].Add(spinner1);
+                        // to connect spinners, we are using the same criteria as "spinner juice" generation in the game.
+                        if (spinner2ID > spinner1ID
+                            && getAttachToSolid(spinner2) == getAttachToSolid(spinner1) && (spinner2.Position - spinner1.Position).LengthSquared() < 576f)
+                        {
+
+                            // register 2 as a neighbor of 1, and 1 as a neighbor of 2.
+                            if (!neighbors.ContainsKey(spinner2))
+                            {
+                                neighbors[spinner2] = new HashSet<SpinnerType>();
+                            }
+
+                            neighbors[spinner1].Add(spinner2);
+                            neighbors[spinner2].Add(spinner1);
+                        }
                     }
                 }
-            }
+
+                spinnerNeighbors = neighbors;
+            }, cancelToken);
         }
 
-        private void shatterSpinner(SpinnerType spinner) {
+        private void shatterSpinner(SpinnerType spinner)
+        {
             // don't break already broken spinners!
             if (spinner.Scene == null) return;
 
             destroySpinner(spinner);
             shatteredSpinners.Add(spinner);
 
-            if (spinnerNeighbors.ContainsKey(spinner)) {
-                foreach (SpinnerType neighbor in spinnerNeighbors[spinner]) {
-                    if (!shatteredSpinners.Contains(neighbor)) {
+            if (spinnerNeighbors.ContainsKey(spinner))
+            {
+                foreach (SpinnerType neighbor in spinnerNeighbors[spinner])
+                {
+                    if (!shatteredSpinners.Contains(neighbor))
+                    {
                         shatterSpinner(neighbor);
                     }
                 }
             }
         }
 
-        private static void onTheoCrystalDie(On.Celeste.TheoCrystal.orig_Die orig, TheoCrystal self) {
-            if (self is SpinnerBreakingBallGeneric<SpinnerType, ColorType>) {
+        private static void onTheoCrystalDie(On.Celeste.TheoCrystal.orig_Die orig, TheoCrystal self)
+        {
+            if (self is SpinnerBreakingBallGeneric<SpinnerType, ColorType>)
+            {
                 self.RemoveSelf();
-            } else {
+            }
+            else
+            {
                 orig(self);
             }
         }


### PR DESCRIPTION
…e if many spinner and spinner breaking balls are in a room

Tested this in Joe cause that had about 1-2 seconds of lag every time you retried, this way it'll work in the background as the animation plays.
I made sure to make it synchronously wait if it detects it is hitting a spinner so that should hopefully cover the one case asynchronous would break (it still helps though cause that is usually not for all spinner break balls)

Had to change the DynData calls to an IDCache since multiple dyndata on the same object seem to crash, this way it always only does it once but keeps a cache of which entity has what ID. 

If you have any improvements in style or code please point them out I kinda stumbled my way through this