### PR TITLE
Speed mode

### DIFF
--- a/Ahorn/entities/maxHelpingHandFlagSwitchGate.jl
+++ b/Ahorn/entities/maxHelpingHandFlagSwitchGate.jl
@@ -4,8 +4,8 @@ using ..Ahorn, Maple
 
 @pardef FlagSwitchGate(x1::Integer, y1::Integer, x2::Integer=x1+16, y2::Integer=y1, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
     sprite::String="block", persistent::Bool=false, flag::String="flag_touch_switch", icon::String="vanilla", inactiveColor::String="5FCDE4", activeColor::String="FFFFFF", finishColor::String="F141DF",
-    shakeTime::Number=0.5, moveTime::Number=1.8, moveEased::Bool=true, allowReturn::Bool=false, moveSound::String="event:/game/general/touchswitch_gate_open", finishedSound::String="event:/game/general/touchswitch_gate_finish",
-    smoke::Bool=true, surfaceIndex::Int16=convert(Int16, 8), particles::Bool=true) =
+    shakeTime::Number=0.5, moveTime::Number=1.8, moveSpeed::Number=60.0, moveEased::Bool=true, allowReturn::Bool=false, moveSound::String="event:/game/general/touchswitch_gate_open", finishedSound::String="event:/game/general/touchswitch_gate_finish",
+    smoke::Bool=true, surfaceIndex::Int16=convert(Int16, 8), particles::Bool=true, speedMode::Bool=false) =
     Entity("MaxHelpingHand/FlagSwitchGate", x=x1, y=y1, nodes=Tuple{Int, Int}[(x2, y2)], width=width, height=height, sprite=sprite, persistent=persistent, flag=flag, icon=icon,
     inactiveColor=inactiveColor, activeColor=activeColor, finishColor=finishColor, shakeTime=shakeTime, moveTime=moveTime, moveEased=moveEased, allowReturn=allowReturn, moveSound=moveSound, finishedSound=finishedSound,
     smoke=smoke, surfaceIndex=surfaceIndex, particles=particles)
@@ -33,7 +33,7 @@ const placements = Ahorn.PlacementDict(
     ) for texture in textures
 )
 
-Ahorn.editingOrder(entity::FlagSwitchGate) = String["x", "y", "width", "height", "flag", "inactiveColor", "activeColor", "finishColor", "hitSound", "moveSound", "finishedSound", "shakeTime", "moveTime"]
+Ahorn.editingOrder(entity::FlagSwitchGate) = String["x", "y", "width", "height", "flag", "inactiveColor", "activeColor", "finishColor", "hitSound", "moveSound", "finishedSound", "shakeTime", "moveTime", "moveSpeed", "icon", "sprite", "surfaceIndex", "allowReturn", "moveEased", "persistent", "particles", "smoke", "speedMode"]
 
 Ahorn.editingOptions(entity::FlagSwitchGate) = Dict{String, Any}(
     "sprite" => textures,

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -56,6 +56,8 @@ placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.finishedSound=The sou
 placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.smoke=Whether the switch gate should emit smoke when reaching its final position.
 placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.surfaceIndex=Footstep sound when walking on the switch gate.
 placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.particles=Whether the switch gate should emit particles while it is moving.
+placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.speedMode=Allows defining move speed, instead of move time.\nFor this change to apply, you must reopen the edit window.
+placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.MoveSpeed=The speed (in pixels per second) the block travels at, if Speed Mode is checked.
 
 # Shatter Flag Switch Gate
 placements.entities.MaxHelpingHand/ShatterFlagSwitchGate.tooltips.flag=The session flag this switch gate reacts to. Give the same to multiple touch switches and switch gates to group them.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -57,7 +57,7 @@ placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.smoke=Whether the swi
 placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.surfaceIndex=Footstep sound when walking on the switch gate.
 placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.particles=Whether the switch gate should emit particles while it is moving.
 placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.speedMode=Allows defining move speed, instead of move time.\nFor this change to apply, you must reopen the edit window.
-placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.MoveSpeed=The speed (in pixels per second) the block travels at, if Speed Mode is checked.
+placements.entities.MaxHelpingHand/FlagSwitchGate.tooltips.moveSpeed=The speed (in pixels per second) the block travels at, if Speed Mode is checked.
 
 # Shatter Flag Switch Gate
 placements.entities.MaxHelpingHand/ShatterFlagSwitchGate.tooltips.flag=The session flag this switch gate reacts to. Give the same to multiple touch switches and switch gates to group them.

--- a/Entities/FlagSwitchGate.cs
+++ b/Entities/FlagSwitchGate.cs
@@ -46,7 +46,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
         private readonly float shakeTime;
         private readonly float moveTime;
+        private readonly float moveSpeed;
         private readonly bool moveEased;
+        private readonly bool speedMode;
 
         private readonly string moveSound;
         private readonly string finishedSound;
@@ -77,7 +79,9 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
             shakeTime = data.Float("shakeTime", 0.5f);
             moveTime = data.Float("moveTime", 1.8f);
+            moveSpeed = data.Float("moveSpeed", 60.0f);
             moveEased = data.Bool("moveEased", true);
+            speedMode = data.Bool("speedMode", false);
 
             moveSound = data.Attr("moveSound", "event:/game/general/touchswitch_gate_open");
             finishedSound = data.Attr("finishedSound", "event:/game/general/touchswitch_gate_finish");
@@ -263,9 +267,19 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             yield return 0.1f;
             if (shouldCancelMove(goingBack)) yield break;
 
-            // move the switch gate, emitting particles along the way
+            // move the switch gate, emitting particles along the way if particles is true
             int particleAt = 0;
-            Tween tween = Tween.Create(Tween.TweenMode.Oneshot, moveEased ? Ease.CubeOut : null, moveTime + (moveEased ? 0.2f : 0f), start: true);
+
+            Tween tween;
+            if (speedMode)
+            {
+                tween = Tween.Create(Tween.TweenMode.Oneshot, null, (float)Math.Round(((Vector2.Distance(start, node)) / moveSpeed), 3), start: true);
+            }
+            else
+            {
+                tween = Tween.Create(Tween.TweenMode.Oneshot, moveEased ? Ease.CubeOut : null, moveTime + (moveEased ? 0.2f : 0f), start: true);
+            }
+
             tween.OnUpdate = tweenArg => {
                 MoveTo(Vector2.Lerp(start, node, tweenArg.Eased));
                 if (particles) {
@@ -285,7 +299,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
             };
             Add(tween);
 
-            float moveTimeLeft = moveTime;
+            float moveTimeLeft = speedMode ? (float)Math.Round(((Vector2.Distance(start, node)) / moveSpeed), 3) : moveTime;
             while (moveTimeLeft > 0f) {
                 yield return null;
                 moveTimeLeft -= Engine.DeltaTime;

--- a/Loenn/entities/flagSwitchGate.lua
+++ b/Loenn/entities/flagSwitchGate.lua
@@ -40,12 +40,14 @@ for i, texture in ipairs(textures) do
             finishedSound = "event:/game/general/touchswitch_gate_finish",
             smoke = true,
             surfaceIndex = 8,
-            particles = true
+            particles = true,
+            speedMode = false,
+            moveSpeed = 60
         }
     }
 end
 
-switchGate.fieldOrder = {"x", "y", "width", "height", "flag", "inactiveColor", "activeColor", "finishColor", "hitSound", "moveSound", "finishedSound", "shakeTime", "moveTime", "icon", "sprite", "surfaceIndex", "allowReturn", "moveEased", "persistent", "particles", "smoke"}
+switchGate.fieldOrder = {"x", "y", "width", "height", "flag", "inactiveColor", "activeColor", "finishColor", "hitSound", "moveSound", "finishedSound", "shakeTime", "moveTime", "moveSpeed", "icon", "sprite", "surfaceIndex", "allowReturn", "moveEased", "persistent", "particles", "smoke", "speedMode"}
 
 switchGate.fieldInformation = {
     inactiveColor = {
@@ -97,6 +99,22 @@ function switchGate.sprite(room, entity)
     table.insert(sprites, middleSprite)
 
     return sprites
+end
+
+function switchGate.ignoredFields(entity)
+    local ignored = {
+        "_id",
+        "_name"
+    }
+
+    if entity.speedMode then
+        table.insert(ignored, "moveTime")
+        table.insert(ignored, "moveEased")
+    else
+        table.insert(ignored, "moveSpeed")
+    end
+
+    return ignored
 end
 
 function switchGate.selection(room, entity)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -212,6 +212,8 @@ entities.MaxHelpingHand/FlagSwitchGate.attributes.description.finishedSound=The 
 entities.MaxHelpingHand/FlagSwitchGate.attributes.description.smoke=Whether the switch gate should emit smoke when reaching its final position.
 entities.MaxHelpingHand/FlagSwitchGate.attributes.description.surfaceIndex=Footstep sound when walking on the switch gate.
 entities.MaxHelpingHand/FlagSwitchGate.attributes.description.particles=Whether the switch gate should emit particles while it is moving.
+entities.MaxHelpingHand/FlagSwitchGate.attributes.description.speedMode=Allows defining move speed, instead of move time.\nFor this change to apply, you must reopen the edit window.
+entities.MaxHelpingHand/FlagSwitchGate.attributes.description.moveSpeed=The speed (in pixels per second) the block travels at.
 
 # Flag Touch Switch
 entities.MaxHelpingHand/FlagTouchSwitch.placements.name.touch_switch=Flag Touch Switch

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 # The mod used to be known as "max480's Helping Hand", and wasn't renamed for compatibility reasons
 - Name: MaxHelpingHand
-  Version: 1.31.1
+  Version: 1.31.2
   DLL: bin/Release/net452/MaxHelpingHand.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
Added a "Speed Mode" checkbox to flag switch gates, if it's true "Move Time" is replaced by "Move Speed", and move time is calculated while taking travel distance into account. Everest.yaml version is 1.31.2.

"Move Eased" is hidden and treated as true if "Speed Mode" is checked, because defining speed while it is eased would be unclear.