### PR TITLE
particle count + alpha options for custom snow

### DIFF
--- a/Ahorn/effects/maxHelpingHandSnowCustomColors.jl
+++ b/Ahorn/effects/maxHelpingHandSnowCustomColors.jl
@@ -2,7 +2,7 @@
 
 using ..Ahorn, Maple
 
-@mapdef Effect "MaxHelpingHand/SnowCustomColors" SnowCustomColors(only::String="*", exclude::String="", colors::String="FF0000,00FF00,0000FF", speedMin::Number=40.0, speedMax::Number=100.0)
+@mapdef Effect "MaxHelpingHand/SnowCustomColors" SnowCustomColors(only::String="*", exclude::String="", colors::String="FF0000,00FF00,0000FF", speedMin::Number=40.0, speedMax::Number=100.0, alpha::Number=1.0, particleCount::Integer=60)
 
 placements = SnowCustomColors
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -502,9 +502,11 @@ placements.entities.MaxHelpingHand/KevinBarrier.tooltips.flashOnHit=Determines w
 placements.entities.MaxHelpingHand/KevinBarrier.tooltips.invisible=If checked, the Kevin barrier will be invisible (doesn't apply to the flashing).
 
 # Snow with Custom Colors
-placements.effects.MaxHelpingHand/SnowCustomColors.tooltips.colors=Comma-separated list of all colors the particles can take from.
+placements.effects.MaxHelpingHand/SnowCustomColors.tooltips.colors=Comma-separated list of all colors the particles can take from.\nVanilla uses 333333,19337F for background snow, FFFFFF,6495ED for foreground snow.
 placements.effects.MaxHelpingHand/SnowCustomColors.tooltips.speedMin=The minimum speed a snowflake can have. Vanilla uses 40 for background snow, 120 for foreground snow.
 placements.effects.MaxHelpingHand/SnowCustomColors.tooltips.speedMax=The maximum speed a snowflake can have. Vanilla uses 100 for background snow, 300 for foreground snow.
+placements.effects.MaxHelpingHand/SnowCustomColors.tooltips.alpha=The alpha of the snow particles.
+placements.effects.MaxHelpingHand/SnowCustomColors.tooltips.particleCount=The number of snow particles to render. Vanilla uses 60.
 
 # Customizable Glass Block
 placements.entities.MaxHelpingHand/CustomizableGlassBlock.tooltips.behindFgTiles=Whether the glass block outline should appear behind foreground tiles.

--- a/Loenn/effects/snowCustomColors.lua
+++ b/Loenn/effects/snowCustomColors.lua
@@ -7,7 +7,29 @@ effect.canForeground = true
 effect.defaultData = {
     colors = "FF0000,00FF00,0000FF",
     speedMin = 40.0,
-    speedMax = 100.0
+    speedMax = 100.0,
+    alpha = 1.0,
+    particleCount = 60
+}
+
+effect.fieldInformation = {
+    colors = {
+        fieldType = "list",
+        minimumElements = 1,
+        elementDefault = "ffffff",
+        elementOptions = {
+            fieldType = "color",
+            allowXNAColors = false
+        }
+    },
+    alpha = {
+        maximumValue = 1.0,
+        minimumValue = 0.0
+    },
+    particleCount = {
+        fieldType = "integer",
+        minimumValue = 1
+    }
 }
 
 return effect

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1308,9 +1308,11 @@ style.effects.MaxHelpingHand/NorthernLightsCustomColors.description.strandCount=
 
 # Snow with Custom Colors
 style.effects.MaxHelpingHand/SnowCustomColors.name=Snow (Custom)
-style.effects.MaxHelpingHand/SnowCustomColors.description.colors=Comma-separated list of all colors the particles can take from.
+style.effects.MaxHelpingHand/SnowCustomColors.description.colors=Comma-separated list of all colors the particles can take from.\nVanilla uses 333333,19337F for background snow, FFFFFF,6495ED for foreground snow.
 style.effects.MaxHelpingHand/SnowCustomColors.description.speedMin=The minimum speed a snowflake can have. Vanilla uses 40 for background snow, 120 for foreground snow.
 style.effects.MaxHelpingHand/SnowCustomColors.description.speedMax=The maximum speed a snowflake can have. Vanilla uses 100 for background snow, 300 for foreground snow.
+style.effects.MaxHelpingHand/SnowCustomColors.description.alpha=The alpha of the snow particles.
+style.effects.MaxHelpingHand/SnowCustomColors.description.particleCount=The number of snow particles to render. Vanilla uses 60.
 
 # Custom Bird Tutorial: extra "Show Hints" placement
 entities.everest/customBirdTutorial.placements.name.maxhelpinghand_showhints=Custom Bird Tutorial (Show Hints)

--- a/Module/MaxHelpingHandModule.cs
+++ b/Module/MaxHelpingHandModule.cs
@@ -417,13 +417,14 @@ namespace Celeste.Mod.MaxHelpingHand.Module {
                 return new CustomStarfield(paths, colors, alphas, child.AttrBool("shuffle", true), child.AttrFloat("speed", 1f));
             }
             if (child.Name.Equals("MaxHelpingHand/SnowCustomColors", StringComparison.OrdinalIgnoreCase)) {
+                float alpha = child.AttrFloat("alpha", 1f);
                 string[] colorsAsStrings = child.Attr("colors").Split(',');
                 Color[] colors = new Color[colorsAsStrings.Length];
                 for (int i = 0; i < colors.Length; i++) {
-                    colors[i] = Calc.HexToColor(colorsAsStrings[i]);
+                    colors[i] = Calc.HexToColor(colorsAsStrings[i]) * alpha;
                 }
 
-                return new SnowCustomColors(colors, child.AttrFloat("speedMin", 40f), child.AttrFloat("speedMax", 100f));
+                return new SnowCustomColors(colors, child.AttrFloat("speedMin", 40f), child.AttrFloat("speedMax", 100f), child.AttrInt("particleCount", 60));
             }
             if (child.Name.Equals("MaxHelpingHand/NorthernLightsCustomColors", StringComparison.OrdinalIgnoreCase)) {
                 string[] colorsAsStrings = child.Attr("colors").Split(',');


### PR DESCRIPTION
felt like these could be useful and couldn't find anything in an existing helper
also added field information to the Lönn plugin for editing the colors more easily (would this be worth adding to other stuff taking lists of colors too?)