### PR TITLE
Update `DreamSwitchGate` namespace

### DIFF
--- a/Entities/FlagTouchSwitch.cs
+++ b/Entities/FlagTouchSwitch.cs
@@ -310,7 +310,7 @@ namespace Celeste.Mod.MaxHelpingHand.Entities {
 
                 // trigger associated dream flag switch gate(s) from Communal Helper
                 foreach (Entity dreamFlagSwitchGate in level.Entities
-                    .Where(entity => entity.GetType().ToString() == "Celeste.Mod.CommunalHelper.DreamSwitchGate")
+                    .Where(entity => entity.GetType().ToString() == "Celeste.Mod.CommunalHelper.Entities.DreamSwitchGate")
                     .Where(dreamSwitchGate => {
                         // said dream switch gate should be flag too, but that's a private field.
                         if (dreamSwitchGateIsFlagSwitchGate == null) {


### PR DESCRIPTION
Communal Helper changed all its entity namespace as part of a code cleanup, which broke the logic in Maddie's Helping Hand for flag touch switches.
See: https://github.com/CommunalHelper/CommunalHelper/commit/bc26b41a96352970d68b7080e5154c91bba0e7a6.

> https://github.com/user-attachments/assets/e60d0105-a250-4f34-8ab7-349cf15dadf1
> 
> (video source: https://discord.com/channels/403698615446536203/1388921867607474367/1388921867607474367)

This PR fixes the issue by updating to the expected namespace.