### PR TITLE
Adds "Revert on Leave" option to Silhouette Trigger

### DIFF
--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -993,6 +993,7 @@ triggers.MaxHelpingHand/MadelinePonytailTrigger.attributes.description.enable=Wh
 # Madeline Silhouette Trigger
 triggers.MaxHelpingHand/MadelineSilhouetteTrigger.placements.name.trigger=Madeline Silhouette
 triggers.MaxHelpingHand/MadelineSilhouetteTrigger.attributes.description.enable=If checked, the trigger will turn Madeline into a silhouette. If unchecked, it will turn Madeline back to normal.
+triggers.MaxHelpingHand/MadelineSilhouetteTrigger.attributes.description.revertOnLeave=If checked, Madeline will revert back to the old state when you leave the trigger.
 
 # One-Way Camera Trigger
 triggers.MaxHelpingHand/OneWayCameraTrigger.placements.name.trigger=One-Way Camera

--- a/Loenn/triggers/madelineSilhouette.lua
+++ b/Loenn/triggers/madelineSilhouette.lua
@@ -9,7 +9,8 @@ trigger.triggerText = generateTriggerName
 trigger.placements = {
     name = "trigger",
     data = {
-        enable = true
+        enable = true,
+        revertOnLeave = false
     }
 }
 

--- a/Triggers/MadelineSilhouetteTrigger.cs
+++ b/Triggers/MadelineSilhouetteTrigger.cs
@@ -99,22 +99,32 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
 
 
         private bool enable;
+        private bool revertOnLeave;
+        private bool valueOnEnter;
 
         public MadelineSilhouetteTrigger(EntityData data, Vector2 offset) : base(data, offset) {
             enable = data.Bool("enable", true);
-            revertOnLeave = data.Bool("onlyActiveWhileInside", false);
+            revertOnLeave = data.Bool("revertOnLeave", false);
         }
 
         public override void OnEnter(Player player) {
             base.OnEnter(player);
-
-            bool oldValue = MaxHelpingHandModule.Instance.Session.MadelineIsSilhouette;
+            valueOnEnter = MaxHelpingHandModule.Instance.Session.MadelineIsSilhouette;
             MaxHelpingHandModule.Instance.Session.MadelineIsSilhouette = enable;
 
             // if the value changed...
-            if (oldValue != enable) {
+            if (valueOnEnter != enable) {
                 // switch modes right now. this uses the same way as turning the "Other Self" variant on.
                 refreshPlayerSpriteMode(player, enable);
+            }
+        }
+
+        public override void OnLeave(Player player)
+        {
+            base.OnLeave(player);
+            if (revertOnLeave && valueOnEnter != MaxHelpingHandModule.Instance.Session.MadelineIsSilhouette) {
+                MaxHelpingHandModule.Instance.Session.MadelineIsSilhouette = !enable;
+                refreshPlayerSpriteMode(player, !enable);
             }
         }
     }

--- a/Triggers/MadelineSilhouetteTrigger.cs
+++ b/Triggers/MadelineSilhouetteTrigger.cs
@@ -102,6 +102,7 @@ namespace Celeste.Mod.MaxHelpingHand.Triggers {
 
         public MadelineSilhouetteTrigger(EntityData data, Vector2 offset) : base(data, offset) {
             enable = data.Bool("enable", true);
+            revertOnLeave = data.Bool("onlyActiveWhileInside", false);
         }
 
         public override void OnEnter(Player player) {


### PR DESCRIPTION
Adds a bool option in Madeline Silhouette triggers to allow them to only affect Madeline when she is inside the trigger. Otherwise, she will be reverted back to whatever state she started with. I made minimal changes to existing code, mostly just adding an override to the OnLeave method. I did a bit of case testing and couldn't find any issue, but feel free to tear it apart if needed.